### PR TITLE
Move code from main.cpp to modules

### DIFF
--- a/src/camera/camera.cpp
+++ b/src/camera/camera.cpp
@@ -1,4 +1,4 @@
-#include "../camera/camera.hpp"
+#include "camera.hpp"
 #include "raylib.h"
 
 IsoCam::IsoCam() {

--- a/src/camera/camera.hpp
+++ b/src/camera/camera.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "raylib.h"
+
+struct IsoCam {
+    Camera3D cam{};
+    float dist = 35.0f;
+    IsoCam();
+    void update();
+    void pan(float dx, float dz);
+    void zoom(float wheel);
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,189 +1,15 @@
 #include "raylib.h"
 #include "raymath.h"
 #include "rlgl.h"
-#include <cstdint>
-#include <cmath>
 
-// ─── Config ────────────────────────────────────────────
-constexpr int   WIN_W = 1280;
-constexpr int   WIN_H = 720;
-constexpr int   MAP_W = 64;
-constexpr int   MAP_H = 64;
-constexpr float TILE  = 1.0f;   // tile size in world units
-constexpr float STEP  = 0.25f;  // vertical metres per height level
+#include "world/world.hpp"
+#include "render/models.hpp"
+#include "render/draw.hpp"
+#include "camera/camera.hpp"
 
-// Track connection bit‑flags
-enum Dir : uint8_t {
-    N  = 1<<0, E  = 1<<1, S  = 1<<2, W  = 1<<3,
-    NE = 1<<4, NW = 1<<5, SE = 1<<6, SW = 1<<7
-};
+constexpr int WIN_W = 1280;
+constexpr int WIN_H = 720;
 
-struct Tile {
-    int     h    = 0;      // height level
-    bool    has  = false;  // has track present
-    uint8_t mask = 0;      // connection mask if track present
-    Color   col  = GREEN;  // surface colour
-};
-static Tile gWorld[MAP_W][MAP_H];
-
-// ─── Models ────────────────────────────────────────────
-static Model gEW, gNS, gDG;   // track models (east‑west, north‑south, diag)
-
-static Model makeCube(float w,float h,float l, Color tint)
-{
-    Mesh m = GenMeshCube(w,h,l);
-    Model mdl = LoadModelFromMesh(m);
-    mdl.materials[0].maps[MATERIAL_MAP_DIFFUSE].color = tint;
-    return mdl;
-}
-
-static void initModels()
-{
-    gEW = makeCube(TILE*0.9f, 0.1f, TILE*0.2f, GRAY);
-    gNS = makeCube(TILE*0.2f, 0.1f, TILE*0.9f, GRAY);
-    gDG = makeCube(TILE*1.0f, 0.1f, TILE*0.2f, GRAY); // rotate 45° when drawn
-}
-
-// ─── Helpers ───────────────────────────────────────────
-static Vector3 toWorld(int x,int y,float yOff=0.0f)
-{
-    return { (x - MAP_W/2) * TILE, yOff, (y - MAP_H/2) * TILE };
-}
-
-static bool tileHasTrack(int x,int y)
-{
-    return x>=0 && x<MAP_W && y>=0 && y<MAP_H && gWorld[x][y].has;
-}
-
-static void recalcMask(int x,int y)
-{
-    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return;
-    if(!gWorld[x][y].has) { gWorld[x][y].mask = 0; return; }
-    uint8_t m = 0;
-    if(tileHasTrack(x,   y-1)) m |= N;
-    if(tileHasTrack(x+1, y  )) m |= E;
-    if(tileHasTrack(x,   y+1)) m |= S;
-    if(tileHasTrack(x-1, y  )) m |= W;
-    if(tileHasTrack(x+1, y-1)) m |= NE;
-    if(tileHasTrack(x-1, y-1)) m |= NW;
-    if(tileHasTrack(x+1, y+1)) m |= SE;
-    if(tileHasTrack(x-1, y+1)) m |= SW;
-    gWorld[x][y].mask = m;
-}
-
-static void toggleTrack(int x,int y)
-{
-    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return;
-    gWorld[x][y].has = !gWorld[x][y].has;
-    for(int dy=-1; dy<=1; ++dy)
-        for(int dx=-1; dx<=1; ++dx)
-            recalcMask(x+dx, y+dy);
-}
-
-static void modifyHeight(int x,int y,int delta)
-{
-    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return;
-    gWorld[x][y].h = Clamp(gWorld[x][y].h + delta, -4, 8);
-}
-
-static void generateHills()
-{
-    for(int y=0; y<MAP_H; ++y)
-        for(int x=0; x<MAP_W; ++x) {
-            float fx = float(x)/MAP_W * 6.283f;
-            float fy = float(y)/MAP_H * 6.283f;
-            int   h  = int(std::round(std::sin(fx)*std::sin(fy) * 3.0f));
-            gWorld[x][y].h   = h;
-            gWorld[x][y].col = (h < 0 ? BLUE : GREEN);
-        }
-}
-
-// ─── Camera ───────────────────────────────────────────
-struct IsoCam {
-    Camera3D cam{};
-    float dist = 35.0f;
-    IsoCam() {
-        cam.target = {0,0,0};
-        cam.up     = {0,1,0};
-        cam.fovy   = 45;
-        cam.projection = CAMERA_PERSPECTIVE;
-        update();
-    }
-    void update() {
-        cam.position = { cam.target.x + dist, cam.target.y + dist, cam.target.z + dist };
-    }
-    void pan(float dx,float dz) {
-        cam.target = Vector3Add(cam.target, {dx,0,dz});
-        update();
-    }
-    void zoom(float wheel) {
-        dist = Clamp(dist - wheel*5.0f, 10.0f, 120.0f);
-        update();
-    }
-};
-
-// ─── Drawing ───────────────────────────────────────────
-static void drawGround()
-{
-    for(int y=0; y<MAP_H; ++y)
-        for(int x=0; x<MAP_W; ++x) {
-            float   h   = gWorld[x][y].h * STEP;
-            Vector3 pos = toWorld(x, y, h/2.0f);
-            DrawCube(pos, TILE, h + 0.05f, TILE, gWorld[x][y].col);
-        }
-}
-
-static void drawTracks()
-{
-    for(int y=0; y<MAP_H; ++y)
-        for(int x=0; x<MAP_W; ++x) {
-            if(!gWorld[x][y].has) continue;
-            uint8_t m = gWorld[x][y].mask;
-            if(!m) continue;
-            Vector3 base = toWorld(x, y, gWorld[x][y].h*STEP + 0.05f);
-            if(m & (E|W)) DrawModel(gEW, base, 1.0f, WHITE);
-            if(m & (N|S)) DrawModel(gNS, base, 1.0f, WHITE);
-            if(m & (NE|SW)) {
-                rlPushMatrix();
-                rlTranslatef(base.x, base.y, base.z);
-                rlRotatef(45, 0,1,0);
-                DrawModel(gDG, {0,0,0}, 1.0f, WHITE);
-                rlPopMatrix();
-            }
-            if(m & (NW|SE)) {
-                rlPushMatrix();
-                rlTranslatef(base.x, base.y, base.z);
-                rlRotatef(-45, 0,1,0);
-                DrawModel(gDG, {0,0,0}, 1.0f, WHITE);
-                rlPopMatrix();
-            }
-        }
-}
-
-static void drawGrid()
-{
-    rlDisableDepthTest();
-    Color g = {255,255,255,30};
-    for(int y=0; y<=MAP_H; ++y)
-        DrawLine3D(toWorld(0,y,0.02f), toWorld(MAP_W,y,0.02f), g);
-    for(int x=0; x<=MAP_W; ++x)
-        DrawLine3D(toWorld(x,0,0.02f), toWorld(x,MAP_H,0.02f), g);
-    rlEnableDepthTest();
-}
-
-// ─── Picking ───────────────────────────────────────────
-static bool pickTile(const IsoCam& c, int& gx, int& gy)
-{
-    Ray ray = GetMouseRay(GetMousePosition(), c.cam);
-    RayCollision hit = GetRayCollisionQuad(ray,
-        {-10000,0,-10000}, {10000,0,-10000}, {10000,0,10000}, {-10000,0,10000});
-    if(!hit.hit) return false;
-    gx = int(std::floor(hit.point.x / TILE + MAP_W/2));
-    gy = int(std::floor(hit.point.z / TILE + MAP_H/2));
-    return gx>=0 && gx<MAP_W && gy>=0 && gy<MAP_H;
-}
-
-// ─── Main ─────────────────────────────────────────────
 int main()
 {
     InitWindow(WIN_W, WIN_H, "Turntable Prototype");
@@ -195,7 +21,6 @@ int main()
     while(!WindowShouldClose()) {
         float dt = GetFrameTime();
 
-        // Camera movement
         float pan = 15.0f * dt;
         if (IsKeyDown(KEY_A)) cam.pan( pan, 0);
         if (IsKeyDown(KEY_D)) cam.pan(-pan, 0);
@@ -203,7 +28,6 @@ int main()
         if (IsKeyDown(KEY_S)) cam.pan(0, -pan);
         cam.zoom(GetMouseWheelMove());
 
-        // Mouse editing
         int gx, gy;
         if (pickTile(cam, gx, gy) && IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
             if (IsKeyDown(KEY_LEFT_SHIFT))       modifyHeight(gx, gy, +1);
@@ -226,4 +50,3 @@ int main()
     CloseWindow();
     return 0;
 }
-

--- a/src/render/draw.cpp
+++ b/src/render/draw.cpp
@@ -1,0 +1,66 @@
+#include "draw.hpp"
+#include "models.hpp"
+#include "../world/world.hpp"
+#include "raylib.h"
+#include "raymath.h"
+#include "rlgl.h"
+#include <cmath>
+
+void drawGround()
+{
+    for(int y=0; y<MAP_H; ++y)
+        for(int x=0; x<MAP_W; ++x) {
+            float   h   = gWorld[x][y].h * STEP;
+            Vector3 pos = toWorld(x, y, h/2.0f);
+            DrawCube(pos, TILE, h + 0.05f, TILE, gWorld[x][y].col);
+        }
+}
+
+void drawTracks()
+{
+    for(int y=0; y<MAP_H; ++y)
+        for(int x=0; x<MAP_W; ++x) {
+            if(!gWorld[x][y].has) continue;
+            uint8_t m = gWorld[x][y].mask;
+            if(!m) continue;
+            Vector3 base = toWorld(x, y, gWorld[x][y].h*STEP + 0.05f);
+            if(m & (E|W)) DrawModel(gEW, base, 1.0f, WHITE);
+            if(m & (N|S)) DrawModel(gNS, base, 1.0f, WHITE);
+            if(m & (NE|SW)) {
+                rlPushMatrix();
+                rlTranslatef(base.x, base.y, base.z);
+                rlRotatef(45, 0,1,0);
+                DrawModel(gDG, {0,0,0}, 1.0f, WHITE);
+                rlPopMatrix();
+            }
+            if(m & (NW|SE)) {
+                rlPushMatrix();
+                rlTranslatef(base.x, base.y, base.z);
+                rlRotatef(-45, 0,1,0);
+                DrawModel(gDG, {0,0,0}, 1.0f, WHITE);
+                rlPopMatrix();
+            }
+        }
+}
+
+void drawGrid()
+{
+    rlDisableDepthTest();
+    Color g = {255,255,255,30};
+    for(int y=0; y<=MAP_H; ++y)
+        DrawLine3D(toWorld(0,y,0.02f), toWorld(MAP_W,y,0.02f), g);
+    for(int x=0; x<=MAP_W; ++x)
+        DrawLine3D(toWorld(x,0,0.02f), toWorld(x,MAP_H,0.02f), g);
+    rlEnableDepthTest();
+}
+
+bool pickTile(const IsoCam& c, int& gx, int& gy)
+{
+    Ray ray = GetMouseRay(GetMousePosition(), c.cam);
+    RayCollision hit = GetRayCollisionQuad(ray,
+        {-10000,0,-10000}, {10000,0,-10000}, {10000,0,10000}, {-10000,0,10000});
+    if(!hit.hit) return false;
+    gx = int(std::floor(hit.point.x / TILE + MAP_W/2));
+    gy = int(std::floor(hit.point.z / TILE + MAP_H/2));
+    return gx>=0 && gx<MAP_W && gy>=0 && gy<MAP_H;
+}

--- a/src/render/draw.hpp
+++ b/src/render/draw.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "../camera/camera.hpp"
+
+void drawGround();
+void drawTracks();
+void drawGrid();
+bool pickTile(const IsoCam& c, int& gx, int& gy);

--- a/src/render/models.cpp
+++ b/src/render/models.cpp
@@ -1,0 +1,19 @@
+#include "models.hpp"
+#include "../world/world.hpp"
+
+Model gEW, gNS, gDG;
+
+static Model makeCube(float w,float h,float l, Color tint)
+{
+    Mesh m = GenMeshCube(w,h,l);
+    Model mdl = LoadModelFromMesh(m);
+    mdl.materials[0].maps[MATERIAL_MAP_DIFFUSE].color = tint;
+    return mdl;
+}
+
+void initModels()
+{
+    gEW = makeCube(TILE*0.9f, 0.1f, TILE*0.2f, GRAY);
+    gNS = makeCube(TILE*0.2f, 0.1f, TILE*0.9f, GRAY);
+    gDG = makeCube(TILE*1.0f, 0.1f, TILE*0.2f, GRAY); // rotate 45° when drawn
+}

--- a/src/render/models.hpp
+++ b/src/render/models.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include "raylib.h"
+
+extern Model gEW, gNS, gDG;
+
+void initModels();

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -1,0 +1,57 @@
+#include "world.hpp"
+#include <cmath>
+
+Tile gWorld[MAP_W][MAP_H];
+
+Vector3 toWorld(int x,int y,float yOff)
+{
+    return { (x - MAP_W/2) * TILE, yOff, (y - MAP_H/2) * TILE };
+}
+
+bool tileHasTrack(int x,int y)
+{
+    return x>=0 && x<MAP_W && y>=0 && y<MAP_H && gWorld[x][y].has;
+}
+
+void recalcMask(int x,int y)
+{
+    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return;
+    if(!gWorld[x][y].has) { gWorld[x][y].mask = 0; return; }
+    uint8_t m = 0;
+    if(tileHasTrack(x,   y-1)) m |= N;
+    if(tileHasTrack(x+1, y  )) m |= E;
+    if(tileHasTrack(x,   y+1)) m |= S;
+    if(tileHasTrack(x-1, y  )) m |= W;
+    if(tileHasTrack(x+1, y-1)) m |= NE;
+    if(tileHasTrack(x-1, y-1)) m |= NW;
+    if(tileHasTrack(x+1, y+1)) m |= SE;
+    if(tileHasTrack(x-1, y+1)) m |= SW;
+    gWorld[x][y].mask = m;
+}
+
+void toggleTrack(int x,int y)
+{
+    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return;
+    gWorld[x][y].has = !gWorld[x][y].has;
+    for(int dy=-1; dy<=1; ++dy)
+        for(int dx=-1; dx<=1; ++dx)
+            recalcMask(x+dx, y+dy);
+}
+
+void modifyHeight(int x,int y,int delta)
+{
+    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return;
+    gWorld[x][y].h = Clamp(gWorld[x][y].h + delta, -4, 8);
+}
+
+void generateHills()
+{
+    for(int y=0; y<MAP_H; ++y)
+        for(int x=0; x<MAP_W; ++x) {
+            float fx = float(x)/MAP_W * 6.283f;
+            float fy = float(y)/MAP_H * 6.283f;
+            int   h  = int(std::round(std::sin(fx)*std::sin(fy) * 3.0f));
+            gWorld[x][y].h   = h;
+            gWorld[x][y].col = (h < 0 ? BLUE : GREEN);
+        }
+}

--- a/src/world/world.hpp
+++ b/src/world/world.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include "raylib.h"
+#include "raymath.h"
+#include <cstdint>
+
+constexpr int   MAP_W = 64;
+constexpr int   MAP_H = 64;
+constexpr float TILE  = 1.0f;   // tile size in world units
+constexpr float STEP  = 0.25f;  // vertical metres per height level
+
+enum Dir : uint8_t {
+    N  = 1<<0, E  = 1<<1, S  = 1<<2, W  = 1<<3,
+    NE = 1<<4, NW = 1<<5, SE = 1<<6, SW = 1<<7
+};
+
+struct Tile {
+    int     h    = 0;      // height level
+    bool    has  = false;  // has track present
+    uint8_t mask = 0;      // connection mask if track present
+    Color   col  = GREEN;  // surface colour
+};
+
+extern Tile gWorld[MAP_W][MAP_H];
+
+Vector3 toWorld(int x,int y,float yOff=0.0f);
+bool tileHasTrack(int x,int y);
+void recalcMask(int x,int y);
+void toggleTrack(int x,int y);
+void modifyHeight(int x,int y,int delta);
+void generateHills();


### PR DESCRIPTION
## Summary
- break up implementation in `src/main.cpp` into world, camera and render modules
- expose types and constants via new headers
- simplify `main.cpp` to use these new modules

## Testing
- `cmake -S . -B build` *(fails: Could not find raylibConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_685f08b7f8988329bdf656a48af7c638