### PR TITLE
Add mouse-driven track preview

### DIFF
--- a/src/render/draw.cpp
+++ b/src/render/draw.cpp
@@ -43,10 +43,33 @@ void drawTracks()
         }
 }
 
+void drawGhostTrack(int x,int y,uint8_t m)
+{
+    if(!m) return;
+    Vector3 base = toWorld(x, y, gWorld[x][y].h*STEP + 0.05f);
+    Color c = {200,200,200,120};
+    if(m == (E|W)) DrawModel(gEW, base, 1.0f, c);
+    if(m == (N|S)) DrawModel(gNS, base, 1.0f, c);
+    if(m == (NE|SW)) {
+        rlPushMatrix();
+        rlTranslatef(base.x, base.y, base.z);
+        rlRotatef(45,0,1,0);
+        DrawModel(gDG,{0,0,0},1.0f,c);
+        rlPopMatrix();
+    }
+    if(m == (NW|SE)) {
+        rlPushMatrix();
+        rlTranslatef(base.x, base.y, base.z);
+        rlRotatef(-45,0,1,0);
+        DrawModel(gDG,{0,0,0},1.0f,c);
+        rlPopMatrix();
+    }
+}
+
 void drawGrid()
 {
     rlDisableDepthTest();
-    Color g = {255,255,255,30};
+    Color g = {0,80,0,255};
     for(int y=0; y<=MAP_H; ++y)
         DrawLine3D(toWorld(0,y,0.02f), toWorld(MAP_W,y,0.02f), g);
     for(int x=0; x<=MAP_W; ++x)
@@ -54,7 +77,7 @@ void drawGrid()
     rlEnableDepthTest();
 }
 
-bool pickTile(const IsoCam& c, int& gx, int& gy)
+bool pickTile(const IsoCam& c, int& gx, int& gy, Vector3* pos)
 {
     Ray ray = GetMouseRay(GetMousePosition(), c.cam);
     RayCollision hit = GetRayCollisionQuad(ray,
@@ -62,5 +85,6 @@ bool pickTile(const IsoCam& c, int& gx, int& gy)
     if(!hit.hit) return false;
     gx = int(std::floor(hit.point.x / TILE + MAP_W/2));
     gy = int(std::floor(hit.point.z / TILE + MAP_H/2));
+    if(pos) *pos = hit.point;
     return gx>=0 && gx<MAP_W && gy>=0 && gy<MAP_H;
 }

--- a/src/render/draw.hpp
+++ b/src/render/draw.hpp
@@ -1,7 +1,10 @@
 #pragma once
 #include "../camera/camera.hpp"
+#include <cstdint>
+#include "raylib.h"
 
 void drawGround();
 void drawTracks();
+void drawGhostTrack(int x,int y,uint8_t mask);
 void drawGrid();
-bool pickTile(const IsoCam& c, int& gx, int& gy);
+bool pickTile(const IsoCam& c, int& gx, int& gy, Vector3* pos = nullptr);

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -8,34 +8,16 @@ Vector3 toWorld(int x,int y,float yOff)
     return { (x - MAP_W/2) * TILE, yOff, (y - MAP_H/2) * TILE };
 }
 
-bool tileHasTrack(int x,int y)
-{
-    return x>=0 && x<MAP_W && y>=0 && y<MAP_H && gWorld[x][y].has;
-}
-
-void recalcMask(int x,int y)
+void placeTrack(int x,int y,uint8_t mask)
 {
     if(x<0||x>=MAP_W||y<0||y>=MAP_H) return;
-    if(!gWorld[x][y].has) { gWorld[x][y].mask = 0; return; }
-    uint8_t m = 0;
-    if(tileHasTrack(x,   y-1)) m |= N;
-    if(tileHasTrack(x+1, y  )) m |= E;
-    if(tileHasTrack(x,   y+1)) m |= S;
-    if(tileHasTrack(x-1, y  )) m |= W;
-    if(tileHasTrack(x+1, y-1)) m |= NE;
-    if(tileHasTrack(x-1, y-1)) m |= NW;
-    if(tileHasTrack(x+1, y+1)) m |= SE;
-    if(tileHasTrack(x-1, y+1)) m |= SW;
-    gWorld[x][y].mask = m;
-}
-
-void toggleTrack(int x,int y)
-{
-    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return;
-    gWorld[x][y].has = !gWorld[x][y].has;
-    for(int dy=-1; dy<=1; ++dy)
-        for(int dx=-1; dx<=1; ++dx)
-            recalcMask(x+dx, y+dy);
+    if(gWorld[x][y].has && gWorld[x][y].mask == mask) {
+        gWorld[x][y].has  = false;
+        gWorld[x][y].mask = 0;
+    } else {
+        gWorld[x][y].has  = true;
+        gWorld[x][y].mask = mask;
+    }
 }
 
 void modifyHeight(int x,int y,int delta)
@@ -46,12 +28,10 @@ void modifyHeight(int x,int y,int delta)
 
 void generateHills()
 {
+    Color ground = {0, 120, 0, 255};
     for(int y=0; y<MAP_H; ++y)
         for(int x=0; x<MAP_W; ++x) {
-            float fx = float(x)/MAP_W * 6.283f;
-            float fy = float(y)/MAP_H * 6.283f;
-            int   h  = int(std::round(std::sin(fx)*std::sin(fy) * 3.0f));
-            gWorld[x][y].h   = h;
-            gWorld[x][y].col = (h < 0 ? BLUE : GREEN);
+            gWorld[x][y].h   = 0;
+            gWorld[x][y].col = ground;
         }
 }

--- a/src/world/world.hpp
+++ b/src/world/world.hpp
@@ -23,8 +23,6 @@ struct Tile {
 extern Tile gWorld[MAP_W][MAP_H];
 
 Vector3 toWorld(int x,int y,float yOff=0.0f);
-bool tileHasTrack(int x,int y);
-void recalcMask(int x,int y);
-void toggleTrack(int x,int y);
+void placeTrack(int x,int y,uint8_t mask);
 void modifyHeight(int x,int y,int delta);
 void generateHills();


### PR DESCRIPTION
## Summary
- generate flat green ground
- store track orientation directly and remove mask recalculation
- add helper to determine track orientation from mouse position
- show transparent ghost track on hovered tile
- darken grid colour

## Testing
- `cmake -S . -B build` *(fails: raylib not found)*
- `cmake --build build` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_685f0eadc4d483299c714625cec2d41d