### PR TITLE
Implement sloped terrain and improved track selection

### DIFF
--- a/src/camera/camera.cpp
+++ b/src/camera/camera.cpp
@@ -15,7 +15,11 @@ void IsoCam::update() {
 }
 
 void IsoCam::pan(float dx, float dz) {
-    cam.target = Vector3Add(cam.target, {dx,0,dz});
+    const float s = 0.70710678f; // 1/sqrt(2)
+    Vector3 right   = { s,0,-s };
+    Vector3 forward = { s,0, s };
+    Vector3 move = Vector3Add(Vector3Scale(right, dx), Vector3Scale(forward, dz));
+    cam.target = Vector3Add(cam.target, move);
     update();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,10 +23,15 @@ int main()
         Vector3 c = toWorld(gx, gy);
         float dx = (pos.x - c.x) / TILE;
         float dz = (pos.z - c.z) / TILE;
-        float ax = fabsf(dx), az = fabsf(dz);
-        if(ax > 0.25f && az > 0.25f)
-            return (uint8_t)((dx>0?E:W) | (dz>0?S:N));
-        return (ax >= az) ? (uint8_t)(E|W) : (uint8_t)(N|S);
+        float dEW   = fabsf(dz);
+        float dNS   = fabsf(dx);
+        float dNESW = fabsf(dx - dz) * 0.7071f;
+        float dNWSE = fabsf(dx + dz) * 0.7071f;
+        float best  = dEW; uint8_t mask = E|W;
+        if(dNS < best)  { best = dNS;  mask = N|S; }
+        if(dNESW < best){ best = dNESW; mask = NE|SW; }
+        if(dNWSE < best){ best = dNWSE; mask = NW|SE; }
+        return mask;
     };
 
     while(!WindowShouldClose()) {

--- a/src/render/draw.cpp
+++ b/src/render/draw.cpp
@@ -10,9 +10,13 @@ void drawGround()
 {
     for(int y=0; y<MAP_H; ++y)
         for(int x=0; x<MAP_W; ++x) {
-            float   h   = gWorld[x][y].h * STEP;
-            Vector3 pos = toWorld(x, y, h/2.0f);
-            DrawCube(pos, TILE, h + 0.05f, TILE, gWorld[x][y].col);
+            Vector3 v00 = cornerPos(x,   y);
+            Vector3 v10 = cornerPos(x+1, y);
+            Vector3 v01 = cornerPos(x,   y+1);
+            Vector3 v11 = cornerPos(x+1, y+1);
+            Color c = gWorld[x][y].col;
+            DrawTriangle3D(v00, v10, v11, c);
+            DrawTriangle3D(v00, v11, v01, c);
         }
 }
 
@@ -23,7 +27,7 @@ void drawTracks()
             if(!gWorld[x][y].has) continue;
             uint8_t m = gWorld[x][y].mask;
             if(!m) continue;
-            Vector3 base = toWorld(x, y, gWorld[x][y].h*STEP + 0.05f);
+            Vector3 base = toWorld(x, y, 0.05f);
             if(m & (E|W)) DrawModel(gEW, base, 1.0f, WHITE);
             if(m & (N|S)) DrawModel(gNS, base, 1.0f, WHITE);
             if(m & (NE|SW)) {
@@ -46,7 +50,7 @@ void drawTracks()
 void drawGhostTrack(int x,int y,uint8_t m)
 {
     if(!m) return;
-    Vector3 base = toWorld(x, y, gWorld[x][y].h*STEP + 0.05f);
+    Vector3 base = toWorld(x, y, 0.05f);
     Color c = {200,200,200,120};
     if(m == (E|W)) DrawModel(gEW, base, 1.0f, c);
     if(m == (N|S)) DrawModel(gNS, base, 1.0f, c);
@@ -70,10 +74,12 @@ void drawGrid()
 {
     rlDisableDepthTest();
     Color g = {0,80,0,255};
-    for(int y=0; y<=MAP_H; ++y)
-        DrawLine3D(toWorld(0,y,0.02f), toWorld(MAP_W,y,0.02f), g);
-    for(int x=0; x<=MAP_W; ++x)
-        DrawLine3D(toWorld(x,0,0.02f), toWorld(x,MAP_H,0.02f), g);
+    for(int y=0; y<MAP_H; ++y)
+        for(int x=0; x<MAP_W; ++x) {
+            Vector3 c = toWorld(x,y,0.02f);
+            DrawLine3D({c.x - TILE/2, c.y, c.z}, {c.x + TILE/2, c.y, c.z}, g);
+            DrawLine3D({c.x, c.y, c.z - TILE/2}, {c.x, c.y, c.z + TILE/2}, g);
+        }
     rlEnableDepthTest();
 }
 

--- a/src/render/models.cpp
+++ b/src/render/models.cpp
@@ -3,6 +3,47 @@
 
 Model gEW, gNS, gDG;
 
+static Mesh makeDiagMesh(float w,float h)
+{
+    float half = TILE/2.0f;
+    float hw   = w/2.0f;
+    float hh   = h/2.0f;
+
+    Vector3 v[8] = {
+        { half, -hh, -half + hw },
+        { half - hw, -hh, -half },
+        { -half, -hh, half - hw },
+        { -half + hw, -hh, half },
+        { half,  hh, -half + hw },
+        { half - hw,  hh, -half },
+        { -half,  hh, half - hw },
+        { -half + hw,  hh, half }
+    };
+
+    unsigned short ind[36] = {
+        0,1,2, 0,2,3,       // bottom
+        4,6,5, 4,7,6,       // top
+        0,4,5, 0,5,1,       // sides
+        1,5,6, 1,6,2,
+        2,6,7, 2,7,3,
+        3,7,4, 3,4,0
+    };
+
+    Mesh m{};
+    m.vertexCount   = 8;
+    m.triangleCount = 12;
+    m.vertices  = (float*)MemAlloc(m.vertexCount*3*sizeof(float));
+    m.indices   = (unsigned short*)MemAlloc(m.triangleCount*3*sizeof(unsigned short));
+    for(int i=0;i<8;++i) {
+        m.vertices[i*3+0] = v[i].x;
+        m.vertices[i*3+1] = v[i].y;
+        m.vertices[i*3+2] = v[i].z;
+    }
+    for(int i=0;i<36;++i) m.indices[i] = ind[i];
+    UploadMesh(&m, false);
+    return m;
+}
+
 static Model makeCube(float w,float h,float l, Color tint)
 {
     Mesh m = GenMeshCube(w,h,l);
@@ -15,5 +56,7 @@ void initModels()
 {
     gEW = makeCube(TILE*0.9f, 0.1f, TILE*0.2f, GRAY);
     gNS = makeCube(TILE*0.2f, 0.1f, TILE*0.9f, GRAY);
-    gDG = makeCube(TILE*1.0f, 0.1f, TILE*0.2f, GRAY); // rotate 45° when drawn
+    Mesh dm = makeDiagMesh(TILE*0.2f, 0.1f);
+    gDG = LoadModelFromMesh(dm);
+    gDG.materials[0].maps[MATERIAL_MAP_DIFFUSE].color = GRAY;
 }

--- a/src/world/world.cpp
+++ b/src/world/world.cpp
@@ -2,10 +2,29 @@
 #include <cmath>
 
 Tile gWorld[MAP_W][MAP_H];
+int  gHeights[MAP_W+1][MAP_H+1];
+
+static float heightAt(int gx,int gy) {
+    gx = Clamp(gx,0,MAP_W);
+    gy = Clamp(gy,0,MAP_H);
+    return gHeights[gx][gy] * STEP;
+}
+
+float getTileHeight(int x,int y) {
+    return (heightAt(x, y) + heightAt(x+1,y) +
+            heightAt(x,y+1) + heightAt(x+1,y+1)) * 0.25f;
+}
+
+Vector3 cornerPos(int x,int y,float yOff)
+{
+    return { (x - MAP_W/2) * TILE, heightAt(x,y)+yOff, (y - MAP_H/2) * TILE };
+}
 
 Vector3 toWorld(int x,int y,float yOff)
 {
-    return { (x - MAP_W/2) * TILE, yOff, (y - MAP_H/2) * TILE };
+    return { (x + 0.5f - MAP_W/2) * TILE,
+             getTileHeight(x,y) + yOff,
+             (y + 0.5f - MAP_H/2) * TILE };
 }
 
 void placeTrack(int x,int y,uint8_t mask)
@@ -22,16 +41,21 @@ void placeTrack(int x,int y,uint8_t mask)
 
 void modifyHeight(int x,int y,int delta)
 {
-    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return;
-    gWorld[x][y].h = Clamp(gWorld[x][y].h + delta, -4, 8);
+    if(x<0||x>MAP_W||y<0||y>MAP_H) return;
+    int* verts[4] = { &gHeights[x][y], &gHeights[x+1][y],
+                      &gHeights[x][y+1], &gHeights[x+1][y+1] };
+    for(int i=0;i<4;++i)
+        *verts[i] = Clamp(*verts[i] + delta, -16, 32);
 }
 
 void generateHills()
 {
     Color ground = {0, 120, 0, 255};
+    for(int y=0; y<=MAP_H; ++y)
+        for(int x=0; x<=MAP_W; ++x)
+            gHeights[x][y] = 0;
+
     for(int y=0; y<MAP_H; ++y)
-        for(int x=0; x<MAP_W; ++x) {
-            gWorld[x][y].h   = 0;
+        for(int x=0; x<MAP_W; ++x)
             gWorld[x][y].col = ground;
-        }
 }

--- a/src/world/world.hpp
+++ b/src/world/world.hpp
@@ -14,13 +14,16 @@ enum Dir : uint8_t {
 };
 
 struct Tile {
-    int     h    = 0;      // height level
     bool    has  = false;  // has track present
     uint8_t mask = 0;      // connection mask if track present
     Color   col  = GREEN;  // surface colour
 };
 
 extern Tile gWorld[MAP_W][MAP_H];
+extern int  gHeights[MAP_W+1][MAP_H+1];
+
+float getTileHeight(int x,int y);
+Vector3 cornerPos(int x,int y,float yOff=0.0f);
 
 Vector3 toWorld(int x,int y,float yOff=0.0f);
 void placeTrack(int x,int y,uint8_t mask);


### PR DESCRIPTION
## Summary
- switch the camera pan to follow isometric axes
- determine track orientation by distance to cell axes
- draw sloped ground using triangle meshes
- build trapezoid mesh for diagonal tracks
- align grid with cell centres

## Testing
- `cmake ..` *(fails: raylib not found)*


------
https://chatgpt.com/codex/tasks/task_e_685f1261b46883298ae7ed9919df90bf