### PR TITLE
Fix grid lines and diagonal track

### DIFF
--- a/src/render/draw.cpp
+++ b/src/render/draw.cpp
@@ -15,8 +15,8 @@ void drawGround()
             Vector3 v01 = cornerPos(x,   y+1);
             Vector3 v11 = cornerPos(x+1, y+1);
             Color c = gWorld[x][y].col;
-            DrawTriangle3D(v00, v10, v11, c);
-            DrawTriangle3D(v00, v11, v01, c);
+            DrawTriangle3D(v00, v11, v10, c); // ensure upward facing
+            DrawTriangle3D(v00, v01, v11, c);
         }
 }
 
@@ -74,12 +74,13 @@ void drawGrid()
 {
     rlDisableDepthTest();
     Color g = {0,80,0,255};
-    for(int y=0; y<MAP_H; ++y)
-        for(int x=0; x<MAP_W; ++x) {
-            Vector3 c = toWorld(x,y,0.02f);
-            DrawLine3D({c.x - TILE/2, c.y, c.z}, {c.x + TILE/2, c.y, c.z}, g);
-            DrawLine3D({c.x, c.y, c.z - TILE/2}, {c.x, c.y, c.z + TILE/2}, g);
-        }
+    for(int y=0; y<=MAP_H; ++y)
+        for(int x=0; x<MAP_W; ++x)
+            DrawLine3D(cornerPos(x,y,0.02f), cornerPos(x+1,y,0.02f), g);
+
+    for(int x=0; x<=MAP_W; ++x)
+        for(int y=0; y<MAP_H; ++y)
+            DrawLine3D(cornerPos(x,y,0.02f), cornerPos(x,y+1,0.02f), g);
     rlEnableDepthTest();
 }
 

--- a/src/render/models.cpp
+++ b/src/render/models.cpp
@@ -10,23 +10,23 @@ static Mesh makeDiagMesh(float w,float h)
     float hh   = h/2.0f;
 
     Vector3 v[8] = {
-        { half, -hh, -half + hw },
-        { half - hw, -hh, -half },
-        { -half, -hh, half - hw },
-        { -half + hw, -hh, half },
-        { half,  hh, -half + hw },
-        { half - hw,  hh, -half },
-        { -half,  hh, half - hw },
-        { -half + hw,  hh, half }
+        { -half + hw, -hh, -half },      // 0
+        { -half,      -hh, -half + hw }, // 1
+        {  half,      -hh,  half - hw }, // 2
+        {  half - hw, -hh,  half },      // 3
+        { -half + hw,  hh, -half },      // 4
+        { -half,       hh, -half + hw }, // 5
+        {  half,       hh,  half - hw }, // 6
+        {  half - hw,  hh,  half }       // 7
     };
 
     unsigned short ind[36] = {
-        0,1,2, 0,2,3,       // bottom
-        4,6,5, 4,7,6,       // top
-        0,4,5, 0,5,1,       // sides
-        1,5,6, 1,6,2,
-        2,6,7, 2,7,3,
-        3,7,4, 3,4,0
+        0,1,2, 2,1,3,       // bottom
+        4,6,5, 6,7,5,       // top
+        0,4,5, 0,5,1,
+        1,5,7, 1,7,3,
+        2,3,7, 2,7,6,
+        0,2,6, 0,6,4
     };
 
     Mesh m{};


### PR DESCRIPTION
## Summary
- ensure ground triangles render right-side up
- draw grid lines along tile edges, not centers
- create diagonal track mesh as a trapezoid so ends align with axes

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "raylib")*

------
https://chatgpt.com/codex/tasks/task_e_685f16508fc883298fc501cf2d321c20